### PR TITLE
kloudless is not yet on npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ##Installation
 
 ```
-npm install kloudless
+npm install git://github.com/Kloudless/kloudless-node
 ```
 
 


### PR DESCRIPTION
I know the library isn't even 24hrs old yet, but I just ran into someone at [hack.UVA](http://hackuva.io) who was confused that their installation wasn't working (because they couldn't `npm install kloudless` as the docs suggest).

This is a PR, rather than an issue, because there's code in it to allow users to install the library before it's on npm, if you're holding off publishing until it's stable.

It's toats cool if you ignore the PR, but I'd encourage you to get it up on npm as soon as possible, even if it's just a dev-release.
