### PR TITLE
Parallel Uploads NodeSDK

### DIFF
--- a/lib/methods/multipart.js
+++ b/lib/methods/multipart.js
@@ -44,6 +44,7 @@ var MultipartUpload = function(options, kloudless) {
   this.account_id = options.account_id;
   this.parent_id = options.parent_id;
   this.name = options.name;
+  this.size = options.size;
   this.overwrite = options.overwrite;
 
   this.max_connections = options.max_connections || 5;
@@ -105,7 +106,8 @@ MultipartUpload.prototype.initialise = function() {
   self.logger.log('Pinging: ' + self._kloudless.getApiEndpoint() + '/accounts/' + self.account_id + '/multipart' + (self.overwrite? '?overwrite=True':''));
   self.logger.log('Sending body:', JSON.stringify({
     parent_id: self.parent_id,
-    name: self.name
+    name: self.name,
+    size: self.size
   }));
 
   return request({
@@ -117,7 +119,8 @@ MultipartUpload.prototype.initialise = function() {
     method: 'POST',
     body: JSON.stringify({
       parent_id: self.parent_id,
-      name: self.name
+      name: self.name,
+      size: self.size
     }),
     agentOptions: self.tls_agent_options,
   })
@@ -128,6 +131,12 @@ MultipartUpload.prototype.initialise = function() {
       if(response.error_code) {
         self.logger.error('Could not initialise session:', response);
         throw new Error('Could not initialise session: ' + JSON.stringify(response));
+      }
+      if(response.parallel_uploads){
+          self.logger.log('This service supports parallel uploads');
+      } else {
+          self.logger.log('This service does not support parallel uploads');
+          self.max_connections = 1;
       }
       self.session_id = response.id;
       self.emit('start', self.session_id);

--- a/test/multipart.js
+++ b/test/multipart.js
@@ -16,6 +16,7 @@ var mpu = kloudless.files.uploadMultipart({
   parent_id: process.env.TEST_ACCOUNT_FOLDER || 'some-folder-id-here',
   file: fs.createReadStream(path.join(__dirname, 'fixtures', test_file)),
   name: test_file,
+  size: fs.statSync(path.join(__dirname, 'fixtures', test_file)).size,
   logging: 'debug'
 });
 


### PR DESCRIPTION
I worked on the Node SDK to enable parallel uploads for services that support it. Based on the response of initialize_multipart, the upload would be handled either in parallel or serially.