### PR TITLE
Send the request after creation

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -171,6 +171,7 @@ BaseResource.prototype = {
             } else {
                 req.write(requestData, 'utf8');
             }
+            req.end();
         }
     }
 };


### PR DESCRIPTION
The request was never being sent when using a mocking library such as [nock](https://github.com/node-nock/nock).
This forces the request to be sent after being created. Not sure why it is working without this during normal usage. Maybe it is being implicitly called. I haven't seen this change cause any issues but maybe someone at Kloudless will have a better idea how this should work.